### PR TITLE
fix: Fix mpv freezing during playback

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,7 @@
 # allplay
 Python based "manage while you consume" media manager
+
+# Installation
+git clone https://github.com/cheethoe/allplay.git
+cd allplay
+python3 -m pip install .

--- a/allplay/config.py
+++ b/allplay/config.py
@@ -29,6 +29,7 @@ class Config(object):
         self.quick_tags = self.raw_config.get("quick_tags") or None
         self.auto_tags = self.raw_config.get("auto_tags") or None
         self.media_handler = self.raw_config.get("media_handler") or os.path.join("usr", "bin", "mpv")
+        self.media_handler_arguments = self.raw_config.get("media_handler_arguments") or None
         self.media_extensions = self.raw_config.get("media_extensions") or list()
         self.non_media_tag = self.raw_config.get("non_media_tag") or 'non.media'
 

--- a/allplay/media.py
+++ b/allplay/media.py
@@ -148,6 +148,9 @@ class Media(object):
 
     def play_media(self):
         command = [ self.config.media_handler ]
+        if self.config.media_handler_arguments:
+            for argument in self.config.media_handler_arguments:
+                command.append(argument)
         if os.path.isfile(self.full_path):
             #formatted_full_path = '"' + self.full_path + '"'
             #command.append(formatted_full_path)
@@ -159,7 +162,7 @@ class Media(object):
                 command.append(media)
         try:
             self.logger.warning("trying to run command: %s" % (command))
-            playing = subprocess.Popen(command, env=dict(os.environ), stdout=subprocess.PIPE)
+            playing = subprocess.Popen(command, env=dict(os.environ), stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
             playing.wait()
             self.increment_times_played()
         except subprocess.CalledProcessError as err:


### PR DESCRIPTION
when playing back media in OSX with mpv, media will freeze after a period of time.  It looks like it's related to piping its stdout or stderr to subprocess.PIPE without actively reading from these pipes, the internal I/O buffers can fill up.  We're now piping to subprocess.DEVNULL to prevent this.
Also added the ability to pass arguments to which ever media handler you choose to use.
Also updated the README for installation.